### PR TITLE
"ArrowForwardIcon" imported twice in the same file

### DIFF
--- a/www/src/views/showcase/featured-sites.js
+++ b/www/src/views/showcase/featured-sites.js
@@ -7,7 +7,6 @@ import hex2rgba from "hex2rgba"
 import { useColorMode } from "theme-ui"
 
 import { screenshot, screenshotHover, withTitleHover } from "../shared/styles"
-import MdArrowForward from "react-icons/lib/md/arrow-forward"
 import ShowcaseItemCategories from "./showcase-item-categories"
 import { ShowcaseIcon } from "../../assets/icons"
 import { mediaQueries, colors } from "gatsby-design-tokens/dist/theme-gatsbyjs-org"
@@ -119,7 +118,7 @@ class FeaturedSites extends Component {
           >
             <span className="title">View all</span>
             {` `}
-            <MdArrowForward sx={{ verticalAlign: `sub` }} />
+            <ArrowForwardIcon sx={{ verticalAlign: `sub` }} />
           </a>
           <div
             css={{


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/learning for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
